### PR TITLE
Added isLinkedEffect to CardEffectFactory.JammingSelfStaticEffect

### DIFF
--- a/Scripts/CardEffectFactory/CanNotBeDeletedByBattle.cs
+++ b/Scripts/CardEffectFactory/CanNotBeDeletedByBattle.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 public partial class CardEffectFactory
 {
     #region Static effect that can't be deleted by battle
-    public static CanNotBeDestroyedByBattleClass CanNotBeDestroyedByBattleStaticEffect(Func<Permanent, Permanent, Permanent, CardSource, bool> canNotBeDestroyedByBattleCondition, Func<Permanent, bool> permanentCondition, bool isInheritedEffect, CardSource card, Func<bool> condition, string effectName)
+    public static CanNotBeDestroyedByBattleClass CanNotBeDestroyedByBattleStaticEffect(Func<Permanent, Permanent, Permanent, CardSource, bool> canNotBeDestroyedByBattleCondition, Func<Permanent, bool> permanentCondition, bool isInheritedEffect, CardSource card, Func<bool> condition, string effectName, bool isLinkedEffect = false)
     {
         CanNotBeDestroyedByBattleClass canNotBeDestroyedByBattleClass = new CanNotBeDestroyedByBattleClass();
         canNotBeDestroyedByBattleClass.SetUpICardEffect(effectName, CanUseCondition, card);
@@ -16,6 +16,11 @@ public partial class CardEffectFactory
         if (isInheritedEffect)
         {
             canNotBeDestroyedByBattleClass.SetIsInheritedEffect(true);
+        }
+
+        if (isLinkedEffect)
+        {
+            canNotBeDestroyedByBattleClass.SetIsLinkedEffect(true);
         }
 
         bool CanUseCondition(Hashtable hashtable)

--- a/Scripts/CardEffectFactory/KeyWordEffects/Jamming.cs
+++ b/Scripts/CardEffectFactory/KeyWordEffects/Jamming.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 public partial class CardEffectFactory
 {
     #region Static effect of [Jamming] on oneself
-    public static CanNotBeDestroyedByBattleClass JammingSelfStaticEffect(bool isInheritedEffect, CardSource card, Func<bool> condition)
+    public static CanNotBeDestroyedByBattleClass JammingSelfStaticEffect(bool isInheritedEffect, CardSource card, Func<bool> condition, bool isLinkedEffect = false)
     {
         bool PermanentCondition(Permanent permanent) => permanent == card.PermanentOfThisCard();
 
@@ -24,12 +24,12 @@ public partial class CardEffectFactory
             return false;
         }
 
-        return JammingStaticEffect(permanentCondition: PermanentCondition, isInheritedEffect: isInheritedEffect, card: card, condition: CanUseCondition);
+        return JammingStaticEffect(permanentCondition: PermanentCondition, isInheritedEffect: isInheritedEffect, card: card, condition: CanUseCondition, isLinkedEffect: isLinkedEffect);
     }
     #endregion
 
     #region Static effect of [Jamming]
-    public static CanNotBeDestroyedByBattleClass JammingStaticEffect(Func<Permanent, bool> permanentCondition, bool isInheritedEffect, CardSource card, Func<bool> condition)
+    public static CanNotBeDestroyedByBattleClass JammingStaticEffect(Func<Permanent, bool> permanentCondition, bool isInheritedEffect, CardSource card, Func<bool> condition, bool isLinkedEffect = false)
     {
         string effectName = "Jamming";
 
@@ -73,7 +73,8 @@ public partial class CardEffectFactory
             isInheritedEffect: isInheritedEffect,
             card: card,
             condition: CanUseCondition,
-            effectName: effectName
+            effectName: effectName,
+            isLinkedEffect: isLinkedEffect
         );
     }
     #endregion


### PR DESCRIPTION
Hoping to unblock https://github.com/DCGO2/DCGO-Card-Scripts/issues/489 with this change.

I just copied what I saw in other CardEffectFactory effects, but I do wonder if these should be updated to use enum flags for things like this?