### PR TITLE
Update BT23_029.cs

### DIFF
--- a/CardEffect/BT23/Yellow/BT23_029.cs
+++ b/CardEffect/BT23/Yellow/BT23_029.cs
@@ -71,8 +71,7 @@ namespace DCGO.CardEffects.BT23
                 bool PermanentCondition(Permanent permanent)
                 {
                     return CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
-                        && (permanent.TopCard.EqualsTraits("Beast") || permanent.TopCard.EqualsTraits("Beastkin") || permanent.TopCard.HasCSTraits)
-                        && permanent != card.PermanentOfThisCard();
+                        && (permanent.TopCard.EqualsTraits("Beast") || permanent.TopCard.EqualsTraits("Beastkin") || permanent.TopCard.HasCSTraits);
                 }
 
                 bool IsOpponentsDigimon(Permanent permanent)

--- a/CardEffect/BT23/Yellow/BT23_029.cs
+++ b/CardEffect/BT23/Yellow/BT23_029.cs
@@ -59,8 +59,7 @@ namespace DCGO.CardEffects.BT23
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card)
-                        && CardEffectCommons.CanTriggerOnPermanentPlay(hashtable, PermanentCondition, null);
+                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card);
                 }
 
                 bool CanActivateCondition(Hashtable hashtable)


### PR DESCRIPTION
Removed the requirement for it to not be this card. Not sure about the null on line 63 and wondering why we have 2 methods to checking traits.