### PR TITLE
ST22_03: Kyubimon Fix Cannot select Renamon

### DIFF
--- a/CardEffect/ST22/Yellow/ST22_03.cs
+++ b/CardEffect/ST22/Yellow/ST22_03.cs
@@ -23,7 +23,7 @@ namespace DCGO.CardEffects.ST22
 
 			bool CanSelectCardCondition(CardSource cardSource)
 			{
-                return cardSource.ContainsCardName("Sakuyamon")
+                return cardSource.ContainsCardName("Renamon")
                         || cardSource.ContainsCardName("Kyubimon")
                         || cardSource.ContainsCardName("Taomon")
                         || cardSource.ContainsCardName("Sakuyamon")


### PR DESCRIPTION
1.12.1 [when moving/when digivolving] is unable to pick up renamons' in it's search