### PR TITLE
Factory methods for common ActivateClasses and Shared Effects

### DIFF
--- a/CardEffect/BT24/Black/BT24_062.cs
+++ b/CardEffect/BT24/Black/BT24_062.cs
@@ -96,10 +96,9 @@ namespace DCGO.CardEffects.BT24
 
             string SharedEffectHash = "BT24_062_EOT_EOOT";
 
-            bool SharedCanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
+            bool AdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
             {
-                return CardEffectCommons.IsExistOnBattleArea(card)
-                    && card.PermanentOfThisCard().DigivolutionCards.Any(cardSource => CanSelectCardCondition(cardSource));
+                return card.PermanentOfThisCard().DigivolutionCards.Any(cardSource => CanSelectCardCondition(cardSource, activateClass));
             } 
 
             bool CanSelectCardCondition(CardSource cardSource)
@@ -159,43 +158,16 @@ namespace DCGO.CardEffects.BT24
                     activateETB: true));
             }
 
-            #endregion
-
-            #region End of Attack
-
-            if (timing == EffectTiming.OnEndAttack)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName, CanUseCondition, card);
-                activateClass.SetUpActivateClass(hash => SharedCanActivateCondition(hash, activateClass), hash => SharedActivateCoroutine(hash, activateClass), 1, true, SharedEffectDescription("End of Attack"));
-                activateClass.SetHashString(SharedEffectHash);
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.IsExistOnBattleArea(card)
-                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
-                }
-            }
-
-            #endregion
-
-            #region End of Opponent's Turn
-
-            if (timing == EffectTiming.OnEndTurn)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName, CanUseCondition, card);
-                activateClass.SetUpActivateClass(hash => SharedCanActivateCondition(hash, activateClass), hash => SharedActivateCoroutine(hash, activateClass), 1, true, SharedEffectDescription("End of Opponent's Turn"));
-                activateClass.SetHashString(SharedEffectHash);
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.IsExistOnBattleArea(card)
-                        && CardEffectCommons.IsOpponentTurn(card);
-                }
-            }
+            CardEffectFactory.ActivateClassesForSharedEffects(cardEffects, timing, card,
+                                                                SharedEffectName,
+                                                                SharedActivateCoroutine,
+                                                                SharedEffectDescription,
+                                                                additionalActivateCondition: AdditionalActivateCondition,
+                                                                optional: true,
+                                                                maxCountPerTurn: 1,
+                                                                hashValue: SharedEffectHash,
+                                                                endOfAttack: true,
+                                                                endOfOpponentTurn: true);
 
             #endregion
 

--- a/CardEffect/BT24/Blue/BT24_026.cs
+++ b/CardEffect/BT24/Blue/BT24_026.cs
@@ -31,10 +31,13 @@ namespace DCGO.CardEffects.BT24
 
             if (timing == EffectTiming.OnDiscardHand)
             {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("If you have 5 or less cards, draw 1", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
-                cardEffects.Add(activateClass);
+                cardEffects.Add(CardEffectFactory.ActivateClass(card,
+                                                                "If you have 5 or less cards, draw 1",
+                                                                CanUseCondition,
+                                                                CanActivateCondition,
+                                                                ActivateCoroutine,
+                                                                EffectDescription(),
+                                                                false));
 
                 string EffectDescription()
                 {
@@ -61,32 +64,14 @@ namespace DCGO.CardEffects.BT24
 
             #region Shared OP/WA
 
-            string SharedHash()
-            {
-                return "OP_WA_BT24_026";
-            }
-
-            string SharedEffectName()
-            {
-                return "Trash a card to give one of your digimon Jamming and Blocker.";
-            }
-
             string SharedEffectDescription(string tag)
             {
                 return $"[{tag}] [Once Per Turn] By trashing 1 card in your hand, 1 of your digimon with the [Demon], [Shaman] or [Titan] trait gains <Jamming> and <Blocker> until your opponent's turn ends.";
             }
 
-            bool SharedCanActivateCondition(Hashtable hashtable)
+            bool AdditionalActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.IsExistOnBattleArea(card))
-                {
-                    if (card.Owner.HandCards.Count >= 1)
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
+                return card.Owner.HandCards.Count >= 1;
             }
 
             bool CanSelectPermanentCondition(Permanent permanent)
@@ -165,41 +150,16 @@ namespace DCGO.CardEffects.BT24
                 }
             }
 
-            #endregion
-
-            #region On Play
-
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass(SharedCanActivateCondition,(hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("On Play"));
-                activateClass.SetHashString(SharedHash());
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-                }
-            }
-
-            #endregion
-
-            #region When Attacking
-
-            if (timing == EffectTiming.OnAllyAttack)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass(SharedCanActivateCondition,(hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Attacking"));
-                activateClass.SetHashString(SharedHash());
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerOnAttack(hashtable, card);
-                }
-            }
+            CardEffectFactory.ActivateClassesForSharedEffects(cardEffects, timing, card, 
+                                                                "Trash a card to give one of your digimon Jamming and Blocker.",
+                                                                SharedActivateCoroutine,
+                                                                SharedEffectDescription,
+                                                                optional: false,
+                                                                maxCountPerTurn: 1,
+                                                                hashValue: "OP_WA_BT24_026",
+                                                                onPlay: true,
+                                                                whenAttacking: true,
+                                                                additionalActivateCondition: AdditionalActivateCondition);
 
             #endregion
 

--- a/CardEffect/BT24/Green/BT24_045.cs
+++ b/CardEffect/BT24/Green/BT24_045.cs
@@ -31,10 +31,13 @@ namespace DCGO.CardEffects.BT24
 
             if (timing == EffectTiming.OnDiscardHand)
             {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("If you have 5 or less cards, draw 1", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
-                cardEffects.Add(activateClass);
+                cardEffects.Add(CardEffectFactory.ActivateClass(card,
+                                                                "If you have 5 or less cards, draw 1",
+                                                                CanUseCondition,
+                                                                CanActivateCondition,
+                                                                ActivateCoroutine,
+                                                                EffectDescription(),
+                                                                false));
 
                 string EffectDescription()
                 {
@@ -61,32 +64,14 @@ namespace DCGO.CardEffects.BT24
 
             #region Shared OP/WA
 
-            string SharedHash()
-            {
-                return "OP_WA_BT24_045";
-            }
-
-            string SharedEffectName()
-            {
-                return "Trash a card to stun an opponent's digimon.";
-            }
-
             string SharedEffectDescription(string tag)
             {
                 return $"[{tag}] [Once Per Turn] By trashing 1 card in your hand, suspend 1 of your opponent's Digimon. It can't unsuspend in their next Unsuspend Phase.";
             }
 
-            bool SharedCanActivateCondition(Hashtable hashtable)
+            bool AdditionalActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.IsExistOnBattleArea(card))
-                {
-                    if (card.Owner.HandCards.Count >= 1)
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
+                return card.Owner.HandCards.Count >= 1;
             }
 
             bool CanSelectPermanentCondition(Permanent permanent)
@@ -169,41 +154,16 @@ namespace DCGO.CardEffects.BT24
                 }
             }
 
-            #endregion
-
-            #region On Play
-
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass(SharedCanActivateCondition,(hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("On Play"));
-                activateClass.SetHashString(SharedHash());
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-                }
-            }
-
-            #endregion
-
-            #region When Attacking
-
-            if (timing == EffectTiming.OnAllyAttack)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass(SharedCanActivateCondition,(hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Attacking"));
-                activateClass.SetHashString(SharedHash());
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerOnAttack(hashtable, card);
-                }
-            }
+            CardEffectFactory.ActivateClassesForSharedEffects(cardEffects, timing, card, 
+                                                                "Trash a card to stun an opponent's digimon.",
+                                                                SharedActivateCoroutine,
+                                                                SharedEffectDescription,
+                                                                optional: false,
+                                                                maxCountPerTurn: 1,
+                                                                hashValue: "OP_WA_BT24_045",
+                                                                onPlay: true,
+                                                                whenAttacking: true,
+                                                                additionalActivateCondition: AdditionalActivateCondition);
 
             #endregion
 

--- a/CardEffect/BT24/Purple/BT24_081.cs
+++ b/CardEffect/BT24/Purple/BT24_081.cs
@@ -84,27 +84,14 @@ namespace DCGO.CardEffects.BT24
 
             #region Shared OP WD WA
 
-            string SharedEffectName()
-            {
-                return "Trash a card to delete all opponent's lowest digimon.";
-            }
-
             string SharedEffectDescription(string tag)
             {
                 return $"[{tag}] By trashing 1 card in your hand, delete all of your opponent's Digimon with the lowest level.";
             }
 
-            bool SharedCanActivateCondition(Hashtable hashtable)
+            bool AdditionalActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.IsExistOnBattleArea(card))
-                {
-                    if (card.Owner.HandCards.Count >= 1)
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
+                return card.Owner.HandCards.Count >= 1;
             }
 
             bool CanSelectPermanentCondition(Permanent permanent)
@@ -158,61 +145,27 @@ namespace DCGO.CardEffects.BT24
                 }
             }
 
-            #endregion
-
-            #region On Play
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass(SharedCanActivateCondition,(hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("On Play"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-                }
-            }
-            #endregion
-
-            #region When Digivolving
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass(SharedCanActivateCondition,(hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("On Play"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-                }
-            }
-            #endregion
-
-            #region When Attacking
-            if (timing == EffectTiming.OnAllyAttack)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass(SharedCanActivateCondition,(hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("When Attacking"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerOnAttack(hashtable, card);
-                }
-            }
+            CardEffectFactory.ActivateClassesForSharedEffects(cardEffects, timing, card, 
+                                                                "Trash a card to delete all opponent's lowest digimon.",
+                                                                SharedActivateCoroutine,
+                                                                SharedEffectDescription,
+                                                                optional: false,
+                                                                onPlay: true,
+                                                                whenDigivolving: true,
+                                                                whenAttacking: true,
+                                                                additionalActivateCondition: AdditionalActivateCondition);
             #endregion
 
             #region On Deletion
 
             if (timing == EffectTiming.OnDestroyedAnyone)
             {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("You may play 1 Titamon or level 5 or lower Titan Digimon", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
-                cardEffects.Add(activateClass);
+                cardEffects.Add(CardEffectFactory.OnDeletionClass(card,
+                                                                    "You may play 1 Titamon or level 5 or lower Titan Digimon",
+                                                                    ActivateCoroutine,
+                                                                    EffectDescription(),
+                                                                    false,
+                                                                    additionalActivateCondition: AdditionalActivateCondition));
 
                 string EffectDescription()
                 {
@@ -224,9 +177,9 @@ namespace DCGO.CardEffects.BT24
                     return CardEffectCommons.CanTriggerOnDeletion(hashtable, card);
                 }
 
-                bool CanActivateCondition(Hashtable hashtable)
+                bool AdditionalActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasCorrectTrait);
+                    return CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasCorrectTrait);
                 }
 
                 bool HasCorrectTrait(CardSource cardSource)

--- a/CardEffect/BT24/Red/BT24_013.cs
+++ b/CardEffect/BT24/Red/BT24_013.cs
@@ -31,10 +31,13 @@ namespace DCGO.CardEffects.BT24
 
             if (timing == EffectTiming.OnDiscardHand)
             {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("If you have 5 or less cards, draw 1", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
-                cardEffects.Add(activateClass);
+                cardEffects.Add(CardEffectFactory.ActivateClass(card,
+                                                                "If you have 5 or less cards, draw 1",
+                                                                CanUseCondition,
+                                                                CanActivateCondition,
+                                                                ActivateCoroutine,
+                                                                EffectDescription(),
+                                                                false));
 
                 string EffectDescription()
                 {
@@ -61,32 +64,14 @@ namespace DCGO.CardEffects.BT24
 
             #region Shared OP/WA
 
-            string SharedHash()
-            {
-                return "OP_WA_BT24_026";
-            }
-
-            string SharedEffectName()
-            {
-                return "Trash a card to delete an opponent's 6k or less digimon.";
-            }
-
             string SharedEffectDescription(string tag)
             {
-                return $"[{tag}] [Once Per Turn] By trashing 1 card in your hand, delete 1 of your opponent's Digimon wiuth 6000 DP or less.";
+                return $"[{tag}] [Once Per Turn] By trashing 1 card in your hand, delete 1 of your opponent's Digimon with 6000 DP or less.";
             }
 
-            bool SharedCanActivateCondition(Hashtable hashtable)
+            bool AdditionalActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.IsExistOnBattleArea(card))
-                {
-                    if (card.Owner.HandCards.Count >= 1)
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
+                return card.Owner.HandCards.Count >= 1;
             }
 
             IEnumerator SharedActivateCoroutine(Hashtable _hashtable, ActivateClass activateClass)
@@ -155,41 +140,16 @@ namespace DCGO.CardEffects.BT24
                 }
             }
 
-            #endregion
-
-            #region On Play
-
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass(SharedCanActivateCondition,(hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("On Play"));
-                activateClass.SetHashString(SharedHash());
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-                }
-            }
-
-            #endregion
-
-            #region When Attacking
-
-            if (timing == EffectTiming.OnAllyAttack)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass(SharedCanActivateCondition,(hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Attacking"));
-                activateClass.SetHashString(SharedHash());
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerOnAttack(hashtable, card);
-                }
-            }
+            CardEffectFactory.ActivateClassesForSharedEffects(cardEffects, timing, card, 
+                                                                "Trash a card to delete an opponent's 6k or less digimon.",
+                                                                SharedActivateCoroutine,
+                                                                SharedEffectDescription,
+                                                                optional: false,
+                                                                maxCountPerTurn: 1,
+                                                                hashValue: "OP_WA_BT24_013",
+                                                                onPlay: true,
+                                                                whenAttacking: true,
+                                                                additionalActivateCondition: AdditionalActivateCondition);
 
             #endregion
 

--- a/CardEffect/BT24/Yellow/BT24_036.cs
+++ b/CardEffect/BT24/Yellow/BT24_036.cs
@@ -92,49 +92,15 @@ namespace DCGO.CardEffects.BT24
                     }
                 }
 
-            #endregion
-
-            #region On Play
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, (hashTable) => SharedActivateCoroutine(hashTable, activateClass), -1, false, SharedEffectDescription("On Play"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card) &&
-                        CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-                }
-
-                bool CanActivateCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card) &&
-                        CardEffectCommons.HasMatchConditionPermanent(SharedCanSelectPermanentCondition);
-                }
-            }
-            #endregion
-
-            #region On Deletion
-
-            if (timing == EffectTiming.OnDestroyedAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, (hashTable) => SharedActivateCoroutine(hashTable, activateClass), -1, false, SharedEffectDescription("On Deletion"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerOnDeletion(hashtable, card);
-                }
-
-                bool CanActivateCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
-                }
-            }
+            CardEffectFactory.ActivateClassesForSharedEffects(cardEffects, timing, card,
+                                                              effectName: SharedEffectName(),
+                                                              activateCoroutine: SharedActivateCoroutine,
+                                                              effectDescription: SharedEffectDescription,
+                                                              optional: false,
+                                                              maxCountPerTurn: -1,
+                                                              onPlay: true,
+                                                              onDeletion: true);
+                                                              
             #endregion
 
             #region Link

--- a/CardEffect/P/Blue/P_215.cs
+++ b/CardEffect/P/Blue/P_215.cs
@@ -36,19 +36,15 @@ namespace DCGO.CardEffects.P
 
             #region Shared WM / OP / WD
 
-            string SharedEffectName()
-                => "By placing 1 [Ice-Snow], [Mineral] or [Rock] Digimon from hand or trash under this, 1 such digimon cannot be returned to deck or de-digivolved.";
-
             string SharedEffectDescription(string tag)
             {
                 return $"[{tag}] By placing 1 level 4 or lower [Ice-Snow], [Mineral] or [Rock] trait card from your hand or trash as this Digimon's bottom digivolution card, until your opponent's turn ends, their effects can't return 1 of your [Ice-Snow], [Mineral] or [Rock] trait Digimon to hands or decks or affect it with <De-Digivolve> effects.";
             }
 
-            bool SharedCanActivateCondition(Hashtable hashtable)
+            bool AdditionalActivateCondition(Hashtable hashtable)
             {
-                return CardEffectCommons.IsExistOnBattleArea(card)
-                    && (CardEffectCommons.HasMatchConditionOwnersHand(card, CardSelectCondition)
-                    || CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CardSelectCondition));
+                return CardEffectCommons.HasMatchConditionOwnersHand(card, CardSelectCondition)
+                    || CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CardSelectCondition);
             }
 
             bool CardSelectCondition(CardSource cardSource)
@@ -241,62 +237,15 @@ namespace DCGO.CardEffects.P
                 }
             }
 
-            #endregion
-
-            #region When Moving
-
-            if (timing == EffectTiming.OnMove)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass(SharedCanActivateCondition, (hashTable) => SharedActivateCoroutine(hashTable, activateClass), -1, true, SharedEffectDescription("When Moving"));
-                cardEffects.Add(activateClass);
-
-                bool PermanentCondition(Permanent permanent)
-                {
-                    return permanent == card.PermanentOfThisCard();
-                }
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card) &&
-                           CardEffectCommons.CanTriggerOnMove(hashtable, PermanentCondition);
-                }
-            }
-
-            #endregion
-
-            #region On Play
-
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass(SharedCanActivateCondition, (hashTable) => SharedActivateCoroutine(hashTable, activateClass), -1, true, SharedEffectDescription("On Play"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-                }
-            }
-
-            #endregion
-
-            #region When Digivolving
-
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass(SharedCanActivateCondition, (hashTable) => SharedActivateCoroutine(hashTable, activateClass), -1, true, SharedEffectDescription("When Digivolving"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-                }
-            }
+            CardEffectFactory.ActivateClassesForSharedEffects(cardEffects, timing, card, 
+                                                "By placing 1 [Ice-Snow], [Mineral] or [Rock] Digimon from hand or trash under this, 1 such digimon cannot be returned to deck or de-digivolved.",
+                                                SharedActivateCoroutine,
+                                                SharedEffectDescription,
+                                                optional: true,
+                                                whenMoving: true,
+                                                onPlay: true,
+                                                whenDigivolving: true,
+                                                additionalActivateCondition: AdditionalActivateCondition);
 
             #endregion
 


### PR DESCRIPTION
I find when I create cards that share an effect, I am generally using the exact same boiler plate every time for the activate class and CanUseCondition declarations, so I've extracted them to a factory method which will add them to the passed cardEffects. I've made the changes to several recently added cards to show how it would work