### PR TITLE
Fix cannot tell which Digivolution card is currently processing

### DIFF
--- a/Scripts/SelectCardEffect.cs
+++ b/Scripts/SelectCardEffect.cs
@@ -471,7 +471,7 @@ public class SelectCardEffect : MonoBehaviourPunCallbacks
                         {
                             if (_skillInfos.Count == 0)
                             {
-                                if (_root == Root.Trash)
+                                if (_root == Root.Trash || _root == Root.DigivolutionCards)
                                 {
                                     SkillInfo[] skillInfoArray = new SkillInfo[RootCards.Count];
 


### PR DESCRIPTION
If 2 King Drasil under Mother Eater for example, or 2 X Antibody Protoform after a DNa digivolve trigger at once, currently you cannot tell which you are currently resolving and risk removing the pending one from the stack, getting only 1 effect