### PR TITLE
Allow user to discard all remaining optional effects

### DIFF
--- a/Scripts/MultipleSkills.cs
+++ b/Scripts/MultipleSkills.cs
@@ -266,13 +266,17 @@ public class MultipleSkills : MonoBehaviourPunCallbacks
                             {
                                 yield return StartCoroutine(GManager.instance.selectCardPanel.OpenSelectCardPanel(
                                 Message: "Multiple effects are triggered.\nChoose which effect to process.",
+                                NotSelectButtonMessage: "Don't activate these effects.",
+                                EndSelectButtonMessage: "End Selection", 
+                                _OnClickNotSelectButtonAction: null, 
+                                _OnClickEndSelectButtonAction: null,
                                 RootCardSources: RootCardSources,
                                 _CanTargetCondition: (cardSource) => true,
                                 _CanTargetCondition_ByPreSelecetedList: null,
                                 _CanEndSelectCondition: null,
                                 _MaxCount: 1,
                                 _CanEndNotMax: false,
-                                _CanNoSelect: () => false,
+                                _CanNoSelect: () => skillInfos_active.All(skillInfo => skillInfo.IsOptional),
                                 CanLookReverseCard: true,
                                 skillInfos: skillInfos_active,
                                 root: SelectCardEffect.Root.None));
@@ -280,6 +284,14 @@ public class MultipleSkills : MonoBehaviourPunCallbacks
                                 if (GManager.instance.selectCardPanel.SelectedIndex.Count > 0)
                                 {
                                     skillIndex = GManager.instance.selectCardPanel.SelectedIndex[0];
+                                } 
+                                else
+                                {
+                                    foreach(SkillInfo skillInfo in skillInfos_active)
+                                    {
+                                        StackedSkillInfos.Remove(skillInfo);
+                                    }
+                                    continue;
                                 }
                             }
 


### PR DESCRIPTION
Provides the option to choose not to activate all remaining optional effects when only optional effects remain to be chosen from.

Useful for certain decks that have a lot of identical optional effects trigger at once but only need to activate 1, like Xros Heart or Eaters.

https://canary.discord.com/channels/839041812932329512/1454784427019210887/1454784427019210887