### PR TITLE
Update EX10-037

### DIFF
--- a/CardEffect/EX10/Purple/EX10_037.cs
+++ b/CardEffect/EX10/Purple/EX10_037.cs
@@ -16,8 +16,9 @@ namespace DCGO.CardEffects.EX10
             if (timing == EffectTiming.OnDiscardLibrary)
             {
                 ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("delete 1 level 4 or lower digimon", CanUseCondition, card);
+                activateClass.SetUpICardEffect("Delete 1 level 4 or lower digimon", CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDiscription());
+                activateClass.SetIsDigimonEffect(true);
                 cardEffects.Add(activateClass);
 
                 string EffectDiscription()


### PR DESCRIPTION
Mark the Trash effect as a Digimon Effect, so that Cannot be effected by Digimon Effect digimon are immune.
I believe since this is not a permanent for the trash effect, the code which automatically sets it to be a Digimon effect is not setting this.