### PR TITLE
Update BT24-087 Use correct Root for condition

### DIFF
--- a/CardEffect/BT24/Purple/BT24_087.cs
+++ b/CardEffect/BT24/Purple/BT24_087.cs
@@ -61,7 +61,7 @@ namespace DCGO.CardEffects.BT24
                         {
                             if (trash.appFusionCondition != null)
                             {
-                                if (trash.CanAppFusionFromTargetPermanent(permanent, true))
+                                if (trash.CanAppFusionFromTargetPermanent(permanent, true, SelectCardEffect.Root.Trash))
                                     return true;
                             }
                         }
@@ -72,7 +72,7 @@ namespace DCGO.CardEffects.BT24
                 bool CanSelectCard(CardSource cardSource, Permanent permanent)
                 {
                     return cardSource.appFusionCondition != null
-                        && cardSource.CanAppFusionFromTargetPermanent(permanent, true)
+                        && cardSource.CanAppFusionFromTargetPermanent(permanent, true, SelectCardEffect.Root.Trash)
                         && (cardSource.EqualsTraits("System")
                             || cardSource.EqualsTraits("Life")
                             || cardSource.EqualsTraits("Transmutation"));
@@ -149,7 +149,7 @@ namespace DCGO.CardEffects.BT24
 
                                 #region Select App Fusion Hand Target
 
-                                int maxCount1 = Math.Min(1, CardEffectCommons.MatchConditionOwnersCardCountInHand(card, trashCard => CanSelectCard(trashCard, selectedPermanent)));
+                                int maxCount1 = Math.Min(1, CardEffectCommons.MatchConditionOwnersCardCountInTrash(card, trashCard => CanSelectCard(trashCard, selectedPermanent)));
                                 List<CardSource> selectedCards = new List<CardSource>();
 
                                 SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();

--- a/Scripts/CardSource.cs
+++ b/Scripts/CardSource.cs
@@ -3063,7 +3063,7 @@ public class CardSource : MonoBehaviour
 
     #region whether target permanent can App Fusion into this card
 
-    public bool CanAppFusionFromTargetPermanent(Permanent targetPermanent, bool PayCost)
+    public bool CanAppFusionFromTargetPermanent(Permanent targetPermanent, bool PayCost, SelectCardEffect.Root root = SelectCardEffect.Root.Hand)
     {
         if (targetPermanent != null)
         {
@@ -3083,7 +3083,7 @@ public class CardSource : MonoBehaviour
                                     {
                                         int cost = appFusionCondition.cost;
 
-                                        cost = GetChangedCostItselef(cost, SelectCardEffect.Root.Hand, new List<Permanent>() { targetPermanent }, checkAvailability: true);
+                                        cost = GetChangedCostItselef(cost, root, new List<Permanent>() { targetPermanent }, checkAvailability: true);
 
                                         if (Owner.MaxMemoryCost < cost)
                                         {


### PR DESCRIPTION
Started going down the wrong route making sure CanAppFusionFromTargetPermanent uses the correct root for its cost calculation before noticing the simpler mistake on line 152. However, I believe the change to CanAppFusionFromTargetPermanent is still valuable.