### PR TITLE
Update BT24-102 Fix duplicate abilities

### DIFF
--- a/CardEffect/BT24/White/BT24_102.cs
+++ b/CardEffect/BT24/White/BT24_102.cs
@@ -164,7 +164,10 @@ namespace DCGO.CardEffects.BT24
                     {
                         List<ICardEffect> candidateEffects = selectedPermanent.EffectList(EffectTiming.OnEnterFieldAnyone)
                                     .Clone()
-                                    .Filter(CanBeEffectCandidate);
+                                    .Filter(CanBeEffectCandidate)
+                                    .GroupBy(effect => effect.EffectName)
+                                    .Select(group => group.FirstOrDefault())
+                                    .ToList();
 
                         if (candidateEffects.Count >= 1)
                         {


### PR DESCRIPTION
When an effect has multiple triggers, it appears in the list twice. Since CanBeEffectCandidate checks that the effect can be used, remove duplicates.