### PR TITLE
Throne room cards

### DIFF
--- a/CardEffect/BT24/Blue/BT24_090.cs
+++ b/CardEffect/BT24/Blue/BT24_090.cs
@@ -84,12 +84,7 @@ namespace DCGO.CardEffects.BT24
                 {
                     if (effectTiming == EffectTiming.OnAllyAttack)
                     {
-                        bool Condition()
-                        {
-                            return CardSourceCondition(cardSource);
-                        }
-
-                        effects.Add(CardEffectFactory.AllianceSelfEffect(false, cardSource, Condition));
+                        effects.Add(CardEffectFactory.AllianceSelfEffect(false, cardSource, null));
                     }
 
                     return effects;

--- a/CardEffect/BT24/Green/BT24_094.cs
+++ b/CardEffect/BT24/Green/BT24_094.cs
@@ -48,8 +48,7 @@ namespace DCGO.CardEffects.BT24
                 #region +2k DP
                 bool CanUseCondition()
                 {
-                    return CardEffectCommons.IsExistInSecurity(card, false) &&
-                           CardEffectCommons.HasMatchConditionPermanent(PermanentCondition);
+                    return CardEffectCommons.IsExistInSecurity(card, false);
                 }
 
                 cardEffects.Add(CardEffectFactory.ChangeDPStaticEffect(
@@ -91,12 +90,7 @@ namespace DCGO.CardEffects.BT24
                 {
                     if (effectTiming == EffectTiming.OnAllyAttack)
                     {
-                        bool Condition()
-                        {
-                            return CardSourceCondition(cardSource);
-                        }
-
-                        effects.Add(CardEffectFactory.AllianceSelfEffect(false, cardSource, Condition));
+                        effects.Add(CardEffectFactory.AllianceSelfEffect(false, cardSource, null));
                     }
 
                     return effects;


### PR DESCRIPTION
2 commits:
First reduces unnecessary conditions to try to cause less lag
Second ensures the Added alliance effect is correctly marked as be an effect added by this card