### PR TITLE
Update BT10_097.cs

### DIFF
--- a/CardEffect/BT10/Blue/BT10_097.cs
+++ b/CardEffect/BT10/Blue/BT10_097.cs
@@ -100,17 +100,17 @@ namespace DCGO.CardEffects.BT10
                     {
                         selectedCards.Add(cardSource);
                         yield return null;
+
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                            cardSources: selectedCards,
+                            activateClass: activateClass,
+                            payCost: false,
+                            isTapped: false,
+                            root: SelectCardEffect.Root.Library,
+                            activateETB: true));
+    
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlaceDelayOptionCards(card: card, cardEffect: activateClass));
                     }
-
-                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
-                        cardSources: selectedCards,
-                        activateClass: activateClass,
-                        payCost: false,
-                        isTapped: false,
-                        root: SelectCardEffect.Root.Library,
-                        activateETB: true));
-
-                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlaceDelayOptionCards(card: card, cardEffect: activateClass));
                 }
             }
 


### PR DESCRIPTION
Fix playing tamer after returning revealed cards when it's reverse order.

All I did was move a bracket down.