### PR TITLE
Update BT21_029.cs

### DIFF
--- a/CardEffect/BT21/Red/BT21_029.cs
+++ b/CardEffect/BT21/Red/BT21_029.cs
@@ -62,7 +62,7 @@ namespace DCGO.CardEffects.BT21
                     canTargetCondition_ByPreSelecetedList: null,
                     canEndSelectCondition: null,
                     maxCount: maxCount,
-                    canNoSelect: true,
+                    canNoSelect: false,
                     canEndNotMax: false,
                     selectPermanentCoroutine: null,
                     afterSelectPermanentCoroutine: null,


### PR DESCRIPTION
With the current issue of not being able to refresh OPTs, we'll be making it mandatory to delete if you use up the OPT.