### PR TITLE
Reset used blitz if a new open state is reached in main phase

### DIFF
--- a/Scripts/TurnStateMachine.cs
+++ b/Scripts/TurnStateMachine.cs
@@ -918,6 +918,14 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
             ResetMainPhaseParameter();
             #endregion
 
+            #region resetting used blitz
+            if (GManager.instance.attackProcess.UsedBlitz)
+            {
+                if (GManager.instance.turnStateMachine.gameContext.Memory <= 0)
+                    GManager.instance.attackProcess.UsedBlitz = false;
+            }
+            #endregion
+
             yield return GManager.instance.photonWaitController.StartWait("SetMainPhase");
 
             if (gameContext.TurnPhase == GameContext.phase.Main)


### PR DESCRIPTION
Currently UsedBlitz is only reset if something sets the memory to a specific value, including passing turn. Adding a check to reset it if the game returns to an open main phase state with memory >= 0.