### PR TITLE
Fix BT18-034 Lucemon EoYT to be able to digivolve with tokens

### DIFF
--- a/CardEffect/BT18/Yellow/BT18_034.cs
+++ b/CardEffect/BT18/Yellow/BT18_034.cs
@@ -411,7 +411,8 @@ namespace DCGO.CardEffects.BT18
 
                                     if (selectedPermanent.TopCard == null)
                                     {
-                                        if (!CardEffectCommons.IsExistOnBattleArea(securityCard))
+                                        if (securityCard.Owner.SecurityCards.Contains(securityCard) 
+                                            || (securityCard.IsToken && !CardEffectCommons.IsExistOnBattleArea(securityCard)))
                                         {
                                             if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsCardLucemonChaosModeCondition))
                                             {

--- a/CardEffect/BT18/Yellow/BT18_034.cs
+++ b/CardEffect/BT18/Yellow/BT18_034.cs
@@ -411,7 +411,7 @@ namespace DCGO.CardEffects.BT18
 
                                     if (selectedPermanent.TopCard == null)
                                     {
-                                        if (securityCard.Owner.SecurityCards.Contains(securityCard))
+                                        if (!CardEffectCommons.IsExistOnBattleArea(securityCard))
                                         {
                                             if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsCardLucemonChaosModeCondition))
                                             {


### PR DESCRIPTION
Issue 91
The code checks if the card has been added to the security. However, tokens cannot be added to the security. So, only checking if the card has left the battle area should do the job.