### PR TITLE
Fix EX4-003 draw timing

### DIFF
--- a/CardEffect/EX4/Black/EX4_003.cs
+++ b/CardEffect/EX4/Black/EX4_003.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 
+// Tsunomon
 namespace DCGO.CardEffects.EX4
 {
     public class EX4_003 : CEntity_Effect

--- a/CardEffect/EX4/Black/EX4_003.cs
+++ b/CardEffect/EX4/Black/EX4_003.cs
@@ -47,7 +47,7 @@ namespace DCGO.CardEffects.EX4
                     {
                         if (CardEffectCommons.IsOwnerTurn(card))
                         {
-                            if (CardEffectCommons.CanTriggerWhenPermanentWouldDigivolve(hashtable, PermanentCondition, CardSourceCondition))//.CanTriggerWhenPermanentDigivolving(hashtable, PermanentCondition))
+                            if (CardEffectCommons.CanTriggerWhenPermanentDigivolving(hashtable, PermanentCondition, CardSourceCondition))
                             {
                                 return true;
 


### PR DESCRIPTION
Should now draw after digivolving happens.

Also want to note after some testing on 1.12.7, drawing does not trigger when tamers digivolve into hybrids like #311 reported.