### PR TITLE
Partial Fix: DigiXros/Assembly not working when multiple cards played

### DIFF
--- a/Scripts/CardController.cs
+++ b/Scripts/CardController.cs
@@ -1614,12 +1614,12 @@ public class PlayPermanentClass
             }
 
             GManager.instance.GetComponent<SelectDNACondition>().ResetSelectDNAConditionClass();
-            GManager.instance.GetComponent<SelectDigiXrosClass>().ResetSelectDigiXrosClass();
-            GManager.instance.GetComponent<SelectAssemblyClass>().ResetSelectAssemblyClass();
 
             yield return GManager.instance.photonWaitController.StartWait("EndPlayPermanent");
         }
-
+        
+        GManager.instance.GetComponent<SelectDigiXrosClass>().ResetSelectDigiXrosClass();
+        GManager.instance.GetComponent<SelectAssemblyClass>().ResetSelectAssemblyClass();
 
         // except [On Play] effect
         bool CardEffectCondition(ICardEffect cardEffect)


### PR DESCRIPTION
Currently if the first Digimon in the list of CardSources is not the one for whom the digixros/assembly is intended, it will not work at all as it gets reset. Now the reset has been moved until after all Digimon are played to ensure it works for 1 of the played Digimon. However, fixing to ensure it works properly for if multiple with digixros were played at once would require a lot more work.