### PR TITLE
Fix EX11-027 Link to enemy and doesn't remove from link cards

### DIFF
--- a/CardEffect/EX11/Green/EX11_027.cs
+++ b/CardEffect/EX11/Green/EX11_027.cs
@@ -57,7 +57,7 @@ namespace DCGO.CardEffects.EX11
 
                 bool CanMaybeLinkPermanent(Permanent permanent)
                 {
-                    return permanent.IsDigimon
+                    return CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
                         && permanent != card.PermanentOfThisCard()
                         && (card.CanLinkToTargetPermanent(permanent, false)
                             || card.Owner.HandCards.Filter(CanSelectCardCondition).Some(cardSource => cardSource.CanLinkToTargetPermanent(permanent, false)));
@@ -119,6 +119,8 @@ namespace DCGO.CardEffects.EX11
                         string notSelectPlayerMessage = "The opponent is choosing from which area to select a card.";
 
                         GManager.instance.userSelectionManager.SetIntSelection(selectionElements: selectionElements, selectPlayer: card.Owner, selectPlayerMessage: selectPlayerMessage, notSelectPlayerMessage: notSelectPlayerMessage);
+
+                        yield return ContinuousController.instance.StartCoroutine(GManager.instance.userSelectionManager.WaitForEndSelect());
 
                         bool doLink = GManager.instance.userSelectionManager.SelectedIntValue != 3;
                         bool fromHand = GManager.instance.userSelectionManager.SelectedIntValue == 2;

--- a/Scripts/Permanent.cs
+++ b/Scripts/Permanent.cs
@@ -1140,7 +1140,11 @@ public class Permanent
             {
                 isFromSameDigimon = true;
 
-                if (addedDigivolutionCard == TopCard)
+                if (LinkedCards.Contains(addedDigivolutionCard))
+                {
+                    RemoveLinkedCard(addedDigivolutionCard, trashCard: false);
+                }
+                else if (addedDigivolutionCard == TopCard)
                 {
                     yield return ContinuousController.instance.StartCoroutine(CardObjectController.RemoveFromAllArea(addedDigivolutionCard));
 


### PR DESCRIPTION
AddDigivolutionCardsBottom was not properly handling Link cards. I actually have concerns that RemoveFromAllarea also does not address link cards but did not want to go too deep on changes here