### PR TITLE
Fix UntilNextUnsuspendPhase timing

### DIFF
--- a/Scripts/CardController.cs
+++ b/Scripts/CardController.cs
@@ -5224,11 +5224,6 @@ public class IUnsuspendPermanents
 
             yield return new WaitForSeconds(0.3f);
         }
-
-        foreach (Permanent permanent in untappedPermanets)
-        {
-            permanent.UntilNextUntapEffects = new List<Func<EffectTiming, ICardEffect>>();
-        }
     }
 }
 

--- a/Scripts/CardEffectCommons/GiveEffect/GiveEffectToPermanent/CanNotUnsuspend.cs
+++ b/Scripts/CardEffectCommons/GiveEffect/GiveEffectToPermanent/CanNotUnsuspend.cs
@@ -33,7 +33,7 @@ public partial class CardEffectCommons
 
         yield return ContinuousController.instance.StartCoroutine(GainCanNotUnsuspend(
             targetPermanent: targetPermanent,
-            effectDuration: EffectDuration.UntilOpponentTurnEnd,
+            effectDuration: EffectDuration.UntilNextUntap,
             activateClass: activateClass,
             condition: CanUseCondition,
             effectName: effectName

--- a/Scripts/TurnStateMachine.cs
+++ b/Scripts/TurnStateMachine.cs
@@ -630,6 +630,8 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
 
         #region アクティブフェイズ終了時までの効果をリセット
         gameContext.TurnPlayer.UntilOwnerActivePhaseEffects = new List<Func<EffectTiming, ICardEffect>>();
+        foreach(Permanent permanent in gameContext.TurnPlayer.GetBattleAreaDigimons())
+            permanent.UntilNextUntapEffects = new List<Func<EffectTiming, ICardEffect>>();
         #endregion
     }
     #endregion


### PR DESCRIPTION
GainCantUnsuspendNextActivePhase now correctly uses the until next unsuspend timing.
Ensure this timing is cleared at the end of the player's unuspend phase.
Do not remove it the next time the card unsuspends, that is not correct for any card currently in the game.