### PR TITLE
Update EX11_066.cs

### DIFF
--- a/CardEffect/EX11/Black/EX11_066.cs
+++ b/CardEffect/EX11/Black/EX11_066.cs
@@ -153,7 +153,11 @@ namespace DCGO.CardEffects.EX11
                         && CardEffectCommons.CanActivateSuspendCostEffect(card);
                 }
 
-                bool PermanentCondition(Permanent permanent) => permanent.TopCard.HasText("Vemmon");
+                bool PermanentCondition(Permanent permanent)
+                {
+                    return permanent.TopCard.HasText("Vemmon")
+                        && CardEffectCommons.IsPermanentExistsOnBattleAreaDigimon(permanent);
+                }
 
                 bool IsVemmon(CardSource cardSource) => cardSource.EqualsCardName("Vemmon");
 


### PR DESCRIPTION
Primary fix on Xeno bugs. This might fix the second listed bug as well but since it's kind of vague, I'd rather see if this fixes it before changing too much else. 

With that said I have issues with line 214 maxCount: 1,

In theory, you could play 2 Vemmon in text via something like Omnimon Zwartz and you could split 2 revealed Vemmon among the 2 digimon. As is, the code will not allow you to do that. It's likely that a similar issue is happening with other similar cards such as EX11 Close.