### PR TITLE
WIP Implement ST24-07 and proposal for how dual cards can handle

### DIFF
--- a/CardEffect/ST24/Yellow/ST24_07.cs
+++ b/CardEffect/ST24/Yellow/ST24_07.cs
@@ -1,0 +1,386 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// Shinegreymon // GeoGrey Sword
+namespace DCGO.CardEffects.ST24
+{
+    public class ST24_07 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Digimon Effects
+
+            #region Can't play this card
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.DualCardCantPlay(card));
+            }
+            #endregion
+
+            #region Alt Digivolution
+            if (timing == EffectTiming.None)
+            {
+                bool PermanentCondition(Permanent permanent)
+                {
+                    return permanent.TopCard.IsLevel5 
+                        && (permanent.TopCard.EqualsTraits("DATA SQUAD")
+                            || permanent.TopCard.ContainsCardName("RizeGreymon"));
+
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(PermanentCondition, 3, true, card, null));
+            }
+            #endregion
+
+            #region Raid
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                cardEffects.Add(CardEffectFactory.RaidSelfEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Piercing
+            if (timing == EffectTiming.OnDetermineDoSecurityCheck)
+            {
+                cardEffects.Add(CardEffectFactory.PierceSelfEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Security Attack +1
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.ChangeSelfSAttackStaticEffect(changeValue: 1, isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Shared WD / WA
+
+            string SharedHashString = "ST24_07_WD_WA";
+
+            string SharedEffectName = "You may play a tamer up to 5 cost from hand or trash. -9k to an enemy Digimon.";
+
+            string SharedEffectDescription(string tag) => $"[{tag}] [Once Per Turn] You may play 1 Tamer card with a play cost of 5 or less from your hand or trash without paying the cost. Then, 1 of your opponent's Digimon gets -9000 DP for the turn.";
+
+            bool SharedCanActivateCondition(Hashtable hashtable) => CardEffectCommons.IsExistOnBattleAreaDigimon(card);
+
+            bool PlayableTamerCard(CardSource cardSource, ActivateClass activateClass)
+            {
+                return cardSource.IsTamer
+                    && cardSource.HasPlayCost
+                    && cardSource.GetCostItself <= 5
+                    && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass);
+            }
+
+            bool EnemyDigimonCondition(Permanent permanent) => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                #region Play Tamer
+                bool PlayTamer = false;
+                bool playFromHand = false;
+                bool playFromTrash = false;
+
+                bool canSelectHand = CardEffectCommons.HasMatchConditionOwnersHand(card, cardSource => PlayableTamerCard(cardSource, activateClass));
+                bool canSelectTrash = CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, cardSource => PlayableTamerCard(cardSource, activateClass));
+
+                if (canSelectHand || canSelectTrash)
+                {
+                    #region User Selection - Play Token or Select Card Location
+
+                    var playOptions = new List<SelectionElement<bool>>()
+                    {
+                        new SelectionElement<bool>(message: $"Play a Tamer", value: true, spriteIndex: 0),
+                        new SelectionElement<bool>(message: $"Don't Play", value: false, spriteIndex: 1)
+                    };
+
+                    string selectPlayerMessage = "Will you play a tamer?";
+                    string notSelectPlayerMessage = "The opponent is choosing if they will play a tamer.";
+
+                    GManager.instance.userSelectionManager.SetBoolSelection(selectionElements: playOptions, selectPlayer: card.Owner, selectPlayerMessage: selectPlayerMessage, notSelectPlayerMessage: notSelectPlayerMessage);
+                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.userSelectionManager.WaitForEndSelect());
+                    PlayTamer = GManager.instance.userSelectionManager.SelectedBoolValue;
+                }
+
+                if (PlayTamer)
+                {
+                    if (canSelectHand && canSelectTrash)
+                    {
+                        List<SelectionElement<bool>> selectionElements1 = new List<SelectionElement<bool>>()
+                        {
+                            new SelectionElement<bool>(message: $"From hand", value : true, spriteIndex: 0),
+                            new SelectionElement<bool>(message: $"From trash", value : false, spriteIndex: 1),
+                        };
+
+                        string selectPlayerMessage1 = "From which area do you select a card?";
+                        string notSelectPlayerMessage1 = "The opponent is choosing from which area to select a card.";
+
+                        GManager.instance.userSelectionManager.SetBoolSelection(selectionElements: selectionElements1, selectPlayer: card.Owner, selectPlayerMessage: selectPlayerMessage1, notSelectPlayerMessage: notSelectPlayerMessage1);
+                    }
+                    else
+                    {
+                        GManager.instance.userSelectionManager.SetBool(canSelectHand);
+                    }
+
+                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.userSelectionManager.WaitForEndSelect());
+
+                    var handOrTrashSelection = GManager.instance.userSelectionManager.SelectedBoolValue;
+                    if (handOrTrashSelection) playFromHand = true;
+                    else playFromTrash = true;
+                }
+
+                #endregion
+
+                CardSource selectedCard = null;
+                IEnumerator SelectCardCoroutine(CardSource cardSource)
+                {
+                    selectedCard = cardSource;
+                    yield return null;
+                }
+
+                if (playFromHand)
+                {
+                    SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                    selectHandEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: cardSource => PlayableTamerCard(cardSource, activateClass),
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: true,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        selectCardCoroutine: SelectCardCoroutine,
+                        afterSelectCardCoroutine: null,
+                        mode: SelectHandEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    selectHandEffect.SetUpCustomMessage("Select 1 tamer to play", "The opponent is selecting 1 tamer to play");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+
+                    if (selectedCard != null) yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                        new List<CardSource>() { selectedCard },
+                        activateClass: activateClass,
+                        payCost: false,
+                        isTapped: false,
+                        root: SelectCardEffect.Root.Hand,
+                        activateETB: true));
+                }
+
+                if (playFromTrash)
+                {
+                    SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                    selectCardEffect.SetUp(
+                        canTargetCondition: cardSource => PlayableTamerCard(cardSource, activateClass),
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        canNoSelect: () => true,
+                        selectCardCoroutine: SelectCardCoroutine,
+                        afterSelectCardCoroutine: null,
+                        message: "Select 1 tamer to play",
+                        maxCount: 1,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        mode: SelectCardEffect.Mode.Custom,
+                        root: SelectCardEffect.Root.Trash,
+                        customRootCardList: null,
+                        canLookReverseCard: true,
+                        selectPlayer: card.Owner,
+                        cardEffect: activateClass);
+
+                    selectCardEffect.SetUpCustomMessage("Select 1 tamer to play", "The opponent is selecting 1 tamer to play");
+                    selectCardEffect.SetUpCustomMessage_ShowCard("Selected Tamer");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+                    if (selectedCard != null) yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                        new List<CardSource>() { selectedCard },
+                        activateClass: activateClass,
+                        payCost: false,
+                        isTapped: false,
+                        root: SelectCardEffect.Root.Trash,
+                        activateETB: true));
+                }
+                #endregion
+
+                if (CardEffectCommons.HasMatchConditionOpponentsPermanent(card, EnemyDigimonCondition))
+                {
+                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectPermanentEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: EnemyDigimonCondition,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: false,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: SelectPermanentCoroutine,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will get DP -9000.", "The opponent is selecting 1 Digimon that will get DP -9000.");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDP(targetPermanent: permanent, changeValue: -9000, effectDuration: EffectDuration.UntilEachTurnEnd, activateClass: activateClass));
+                    }
+                }
+            }
+            #endregion
+
+            #region When Digivolving
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName, CanUseCondition, card);
+                activateClass.SetUpActivateClass(SharedCanActivateCondition, hash => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Digivolving"));
+                activateClass.SetHashString(SharedHashString);
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card) &&
+                           CardEffectCommons.IsExistOnBattleAreaDigimon(card);
+                }
+            }
+            #endregion
+
+            #region When Attacking
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName, CanUseCondition, card);
+                activateClass.SetUpActivateClass(SharedCanActivateCondition, hash => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Digivolving"));
+                activateClass.SetHashString(SharedHashString);
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerOnAttack(hashtable, card) &&
+                           CardEffectCommons.IsExistOnBattleAreaDigimon(card);
+                }
+            }
+            #endregion
+
+            #endregion 
+
+            #region Option Effects
+
+            #region Ignore Colour Requirement
+            if (timing == EffectTiming.None)
+            {
+                IgnoreColorConditionClass ignoreColorConditionClass = new IgnoreColorConditionClass();
+                ignoreColorConditionClass.SetUpICardEffect("Ignore color requirements", CanUseCondition, card);
+                ignoreColorConditionClass.SetUpIgnoreColorConditionClass(cardCondition: CardCondition);
+                cardEffects.Add(ignoreColorConditionClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.HasMatchConditionOwnersPermanent(card, PermanentCondition);
+                }
+
+                bool PermanentCondition(Permanent permanent)
+                {
+                    return (permanent.IsDigimon || permanent.IsTamer)
+                        && permanent.TopCard.EqualsTraits("DATA SQUAD");
+                }
+
+                bool CardCondition(CardSource cardSource)
+                {
+                    return cardSource == card;
+                }
+
+            }
+            #endregion
+
+            #region Main
+            if (timing == EffectTiming.OptionSkill)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("1 Enemy Digmon gets -6k  DP, Delete 1 Enemy Digimon with 7k or less DP.", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDiscription());
+                cardEffects.Add(activateClass);
+
+                string EffectDiscription()
+                    => "[Main] 1 of your opponent's Digimon gets -6000 DP for the turn. Then, delete 1 of your opponent's Digimon with 7000 DP or less.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanTriggerOptionMainEffect(hashtable, card);
+
+                bool CanSelectDPMinusPermanentCondition(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
+
+                bool CanSelectDeletePermamentCondition(Permanent permanent)
+                {
+                    return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
+                        && permanent.DP <= 7000;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    if (CardEffectCommons.HasMatchConditionOpponentsPermanent(card, CanSelectDPMinusPermanentCondition))
+                    {
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: CanSelectDPMinusPermanentCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: SelectPermanentCoroutine,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Custom,
+                            cardEffect: activateClass);
+
+                        selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will get DP -6000.", "The opponent is selecting 1 Digimon that will get DP -6000.");
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                        IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDP(targetPermanent: permanent, changeValue: -6000, effectDuration: EffectDuration.UntilEachTurnEnd, activateClass: activateClass));
+                        }
+                    }
+
+                    if(CardEffectCommons.HasMatchConditionOpponentsPermanent(card, CanSelectDeletePermamentCondition))
+                    {
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: CanSelectDeletePermamentCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: null,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Destroy,
+                            cardEffect: activateClass);
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                    }
+
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ArtsDigivolve(card, activateClass));
+                }
+            }
+            #endregion
+
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/CardEffect/ST24/Yellow/ST24_07.cs
+++ b/CardEffect/ST24/Yellow/ST24_07.cs
@@ -305,7 +305,7 @@ namespace DCGO.CardEffects.ST24
             if (timing == EffectTiming.OptionSkill)
             {
                 ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("1 Enemy Digmon gets -6k  DP, Delete 1 Enemy Digimon with 7k or less DP.", CanUseCondition, card);
+                activateClass.SetUpICardEffect("1 Enemy Digimon gets -6k  DP, Delete 1 Enemy Digimon with 7k or less DP.", CanUseCondition, card);
                 activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDiscription());
                 cardEffects.Add(activateClass);
 
@@ -372,8 +372,6 @@ namespace DCGO.CardEffects.ST24
 
                         yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
                     }
-
-                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ArtsDigivolve(card, activateClass));
                 }
             }
             #endregion

--- a/Scripts/CEntity_Base.cs
+++ b/Scripts/CEntity_Base.cs
@@ -42,6 +42,8 @@ public class CEntity_Base : ScriptableObject
     public int MaxCountInDeck = 4;
     public bool HasLoadStarted { get; set; } = false;
     public Sprite CardSprite { get; set; } = null;
+
+    public List<CardColor> DualCardColors = new List<CardColor>();
     public async Task LoadCardImage()
     {
         if (String.IsNullOrEmpty(CardSpriteName))
@@ -232,7 +234,7 @@ public class CEntity_Base : ScriptableObject
     #endregion
 
     #region whether it is permanent card
-    public bool IsPermanent => cardKind == CardKind.Digimon || cardKind == CardKind.Tamer || cardKind == CardKind.DigiEgg;
+    public bool IsPermanent => cardKind == CardKind.Digimon || cardKind == CardKind.Tamer || cardKind == CardKind.DigiEgg || cardKind == CardKind.DualCard;
     #endregion
 
     #region �J�[�hIndex���f�b�L�R�[�h�ɗp���镶����ɕϊ�(256�i��)
@@ -315,12 +317,12 @@ public class CEntity_Base : ScriptableObject
     {
         get
         {
-            if (Level == 0)
+            if (Level <= 0)
             {
                 return false;
             }
 
-            if (cardKind != CardKind.Digimon && cardKind != CardKind.DigiEgg)
+            if (cardKind != CardKind.Digimon && cardKind != CardKind.DigiEgg && cardKind != CardKind.DualCard)
             {
                 return false;
             }
@@ -335,11 +337,11 @@ public class CEntity_Base : ScriptableObject
     #endregion
 
     #region Wheter the card has play cost
-    public bool HasPlayCost => cardKind != CardKind.Option && PlayCost >= 0;
+    public bool HasPlayCost => cardKind != CardKind.Option && cardKind != CardKind.DualCard && PlayCost >= 0;
     #endregion
 
     #region Wheter the card has use cost
-    public bool HasUseCost => cardKind == CardKind.Option && PlayCost >= 0;
+    public bool HasUseCost => (cardKind == CardKind.Option || cardKind == CardKind.DualCard) && PlayCost >= 0;
     #endregion
 }
 public enum CardKind
@@ -348,6 +350,7 @@ public enum CardKind
     Tamer,
     Option,
     DigiEgg,
+    DualCard
 }
 
 [Serializable]

--- a/Scripts/CardController.cs
+++ b/Scripts/CardController.cs
@@ -1753,6 +1753,11 @@ public class UseOptionClass
 
             #endregion
 
+            if (card.Owner.ExecutingCards.Contains(card) && card.IsDualCard)
+            {
+                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ArtsDigivolve(card));
+            }
+
             if (card.Owner.ExecutingCards.Contains(card))
             {
                 if (_addSecurityEndOption && card.Owner.CanAddSecurity(CardEffect))

--- a/Scripts/CardController.cs
+++ b/Scripts/CardController.cs
@@ -997,8 +997,9 @@ public class PlayCardClass
 
         #region filter cards
 
-        List<CardSource> permanentCards = playedCards_fixed.Filter(cardSource => cardSource.IsPermanent);
-        List<CardSource> optionCards = playedCards_fixed.Filter(cardSource => !cardSource.IsPermanent);
+        bool isDualCardAsOption(CardSource cardSource) => cardSource.IsDualCard && !isEvolution;
+        List<CardSource> permanentCards = playedCards_fixed.Filter(cardSource => cardSource.IsPermanent && !isDualCardAsOption(cardSource));
+        List<CardSource> optionCards = playedCards_fixed.Filter(cardSource => !cardSource.IsPermanent || isDualCardAsOption(cardSource));
 
         #region play permanent
 

--- a/Scripts/CardEffectCommons.cs
+++ b/Scripts/CardEffectCommons.cs
@@ -980,7 +980,7 @@ public partial class CardEffectCommons
     #endregion
 
     #region Arts Digivolve
-    public static IEnumerator ArtsDigivolve(CardSource card, ActivateClass activateClass)
+    public static IEnumerator ArtsDigivolve(CardSource card, ActivateClass activateClass = null)
     {
         Permanent targetPermanent = null;
 
@@ -1015,7 +1015,16 @@ public partial class CardEffectCommons
         yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
 
         if (targetPermanent != null)
-            yield return DigivolveIntoExcecutingAreaCard(targetPermanent, null, false, null, null, -1, activateClass, null, true);
+        {
+            yield return ContinuousController.instance.StartCoroutine(new PlayCardClass(
+                cardSources: new List<CardSource>() { card },
+                hashtable: CardEffectHashtable(activateClass),
+                payCost: false,
+                targetPermanent: targetPermanent,
+                isTapped: false,
+                root: SelectCardEffect.Root.Execution,
+                activateETB: true).PlayCard());
+        }
     }
     #endregion
 

--- a/Scripts/CardEffectCommons.cs
+++ b/Scripts/CardEffectCommons.cs
@@ -979,6 +979,46 @@ public partial class CardEffectCommons
 
     #endregion
 
+    #region Arts Digivolve
+    public static IEnumerator ArtsDigivolve(CardSource card, ActivateClass activateClass)
+    {
+        Permanent targetPermanent = null;
+
+        bool PermanentCondition(Permanent permanent) 
+            => card.CanPlayCardTargetFrame(permanent.PermanentFrame, false, activateClass, isBreedingArea: true)
+            || card.CanPlayCardTargetFrame(permanent.PermanentFrame, false, activateClass, isBreedingArea: false);
+
+        IEnumerator SelectPermanentCoroutine(Permanent permanent)
+        {
+            targetPermanent = permanent;
+
+            yield return null;
+        }
+
+        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+        selectPermanentEffect.SetUp(
+            selectPlayer: card.Owner,
+            canTargetCondition: PermanentCondition,
+            canTargetCondition_ByPreSelecetedList: null,
+            canEndSelectCondition: null,
+            maxCount: 1,
+            canNoSelect: true,
+            canEndNotMax: false,
+            selectPermanentCoroutine: null,
+            afterSelectPermanentCoroutine: null,
+            mode: SelectPermanentEffect.Mode.Custom,
+            cardEffect: activateClass);
+
+        selectPermanentEffect.SetUpCustomMessage("Select a digimon to Arts Digivolve.", "Opponent is selecting a digimon to Arts Digivolve.");
+
+        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+        if (targetPermanent != null)
+            yield return DigivolveIntoExcecutingAreaCard(targetPermanent, null, false, null, null, -1, activateClass, null, true);
+    }
+    #endregion
+
     #region Target permanent Digivolves into Digimon card execution area
 
     public static IEnumerator DigivolveIntoExcecutingAreaCard(

--- a/Scripts/CardEffectFactory.cs
+++ b/Scripts/CardEffectFactory.cs
@@ -627,4 +627,29 @@ public partial class CardEffectFactory
     }
 
     #endregion
+
+    #region Can't play this dual card
+    public static ICardEffect DualCardCantPlay(CardSource card)
+    {
+        CanNotPutFieldClass canNotPutFieldClass = new CanNotPutFieldClass();
+        canNotPutFieldClass.SetUpICardEffect("Can't play to the field.", CanUseCondition, card);
+        canNotPutFieldClass.SetUpCanNotPutFieldClass(cardCondition: CardCondition, cardEffectCondition: CardEffectCondition);
+        return canNotPutFieldClass;
+
+        bool CanUseCondition(Hashtable hashtable)
+        {
+            return true;
+        }
+
+        bool CardCondition(CardSource cardSource)
+        {
+            return cardSource == card;
+        }
+
+        bool CardEffectCondition(ICardEffect cardEffect)
+        {
+            return true;
+        }
+    }
+    #endregion
 }

--- a/Scripts/CardSource.cs
+++ b/Scripts/CardSource.cs
@@ -108,12 +108,17 @@ public class CardSource : MonoBehaviour
     {
         get
         {
+            if (IsDualCard && owner.GetBattleAreaDigimons().Some(permanent => CanPlayCardTargetFrame(permanent.PermanentFrame, true, null)))
+            {
+                return true;
+            }
+
             if (CanNotPlayThisOption)
             {
                 return false;
             }
 
-            if (_cEntity_Base.IsPermanent)
+            if (_cEntity_Base.IsPermanent && !IsDualCard)
             {
                 if (!CanPlayJogress(true))
                 {

--- a/Scripts/TurnStateMachine.cs
+++ b/Scripts/TurnStateMachine.cs
@@ -2055,22 +2055,25 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
                             {
                                 bool CanPlayEmptyFrame = false;
 
-                                foreach (FieldCardFrame fieldCardFrame in GManager.instance.You.fieldCardFrames)
+                                if (!handCard1.cardSource.IsDualCard)
                                 {
-                                    if (fieldCardFrame.IsEmptyFrame())
+                                    foreach (FieldCardFrame fieldCardFrame in GManager.instance.You.fieldCardFrames)
                                     {
-                                        if (handCard1.cardSource.CanPlayCardTargetFrame(fieldCardFrame, true, null))
+                                        if (fieldCardFrame.IsEmptyFrame())
                                         {
-                                            CanPlayEmptyFrame = true;
-                                            break;
+                                            if (handCard1.cardSource.CanPlayCardTargetFrame(fieldCardFrame, true, null))
+                                            {
+                                                CanPlayEmptyFrame = true;
+                                                break;
+                                            }
                                         }
                                     }
-                                }
 
-                                if (CanPlayEmptyFrame)
-                                {
-                                    GManager.instance.You.playMatCardFrame.Frame.transform.parent.gameObject.SetActive(true);
-                                    GManager.instance.You.playMatCardFrame.OnFrame_Select(DataBase.SelectColor_Blue);
+                                    if (CanPlayEmptyFrame)
+                                    {
+                                        GManager.instance.You.playMatCardFrame.Frame.transform.parent.gameObject.SetActive(true);
+                                        GManager.instance.You.playMatCardFrame.OnFrame_Select(DataBase.SelectColor_Blue);
+                                    }
                                 }
 
                                 foreach (FieldCardFrame fieldCardFrame in GManager.instance.You.fieldCardFrames)
@@ -2091,7 +2094,7 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
                             #endregion
 
                             #region オプション
-                            else if (handCard1.cardSource.IsOption)
+                            if (handCard1.cardSource.IsOption && !handCard1.cardSource.IsDualCard)
                             {
                                 GManager.instance.You.playMatCardFrame.Frame.transform.parent.gameObject.SetActive(true);
                                 GManager.instance.You.playMatCardFrame.OnFrame_Select(DataBase.SelectColor_Blue);
@@ -2520,14 +2523,21 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
 
                                     bool CanPlayEmptyFrame = false;
 
-                                    foreach (FieldCardFrame fieldCardFrame in GManager.instance.You.fieldCardFrames)
+                                    if (handCard.cardSource.IsDualCard)
                                     {
-                                        if (fieldCardFrame.IsEmptyFrame())
+                                        CanPlayEmptyFrame = true;
+                                    }
+                                    else
+                                    {
+                                        foreach (FieldCardFrame fieldCardFrame in GManager.instance.You.fieldCardFrames)
                                         {
-                                            if (handCard.cardSource.CanPlayCardTargetFrame(fieldCardFrame, true, null))
+                                            if (fieldCardFrame.IsEmptyFrame())
                                             {
-                                                CanPlayEmptyFrame = true;
-                                                break;
+                                                if (handCard.cardSource.CanPlayCardTargetFrame(fieldCardFrame, true, null))
+                                                {
+                                                    CanPlayEmptyFrame = true;
+                                                    break;
+                                                }
                                             }
                                         }
                                     }
@@ -2556,8 +2566,14 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
 
                                             GManager.instance.You.playMatCardFrame.RemoveClickTarget();
                                             GManager.instance.You.playMatCardFrame.Frame.transform.parent.gameObject.SetActive(false);
-
-                                            photonView.RPC("SetPlayCard", RpcTarget.All, handCard.cardSource.CardIndex, handCard.cardSource.PreferredFrame().FrameID, new int[0], -1, new int[0]);
+                                            if (handCard.cardSource.IsDualCard)
+                                            {
+                                                photonView.RPC("SetPlayCard", RpcTarget.All, handCard.cardSource.CardIndex, 0, new int[0], -1, new int[0]);
+                                            }
+                                            else 
+                                            {
+                                                photonView.RPC("SetPlayCard", RpcTarget.All, handCard.cardSource.CardIndex, handCard.cardSource.PreferredFrame().FrameID, new int[0], -1, new int[0]);
+                                            }
                                             selected = true;
 
                                             return;


### PR DESCRIPTION
TODO:

- [x] Arts Digivolution is not by effect. Need to separate it from activateClass.
- [ ] Change all instances of CardSource.CardColors.Contains to CardSource.HasCardColor everywhere. Not going to this effort until we confirm the approach
- [x] Make it so when player drags a DualCard that is seen as using the option
- [ ] Update json parsing to populate DualCardColors when present. and to recognise when cardkind is dualcard
- [ ] Tweaking to the right click window and deck buildign screen to display all information.
- [ ] Further changes to cEntity_Base to store the separate effect field for the option half.
- [ ] Update cards which trash Delay options such as BT19-064 Justimon, BT18-100 Gospel of the Fallen Angel to NOT delete DualCards, depending on rulings

I am not suggesting all of the above will be done by me, just trying to track all things likely to be needed