### PR TITLE
Fix Shoutmon X7: SM not working from under Kotone

### DIFF
--- a/CardEffect/BT12/White/BT12_112.cs
+++ b/CardEffect/BT12/White/BT12_112.cs
@@ -17,11 +17,12 @@ namespace DCGO.CardEffects.BT12
                 activateClass.SetUpICardEffect("Play Cost -1 and select trash cards for a DigiXros", CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDiscription());
                 activateClass.SetHashString("PlayCost-1_BT12_112");
+                activateClass.SetIsEffectOfCard(true);
                 cardEffects.Add(activateClass);
 
                 string EffectDiscription()
                 {
-                    return "When you would play this card from your hand, by placing 1 of your [Shoutmon] as a digivolution card under this Digimon, reduce its play cost by 1 and place the cards in your trash as digivolution cards for a DigiXros.";
+                    return "When you would play this card, by placing 1 [Shoutmon] as a digivolution card under this Digimon, reduce its play cost by 1 and place the cards in your trash as digivolution cards for a DigiXros.";
                 }
 
                 bool CanSelectPermanentCondition(Permanent permanent)

--- a/CardEffect/BT21/Red/BT21_030.cs
+++ b/CardEffect/BT21/Red/BT21_030.cs
@@ -126,12 +126,13 @@ namespace DCGO.CardEffects.BT21
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Play Cost -1 and select trash cards for a DigiXros", CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDiscription());
-                activateClass.SetHashString("PlayCost-1_BT12_112");
+                activateClass.SetHashString("PlayCost-1_BT21_030");
+                activateClass.SetIsEffectOfCard(true);
                 cardEffects.Add(activateClass);
 
                 string EffectDiscription()
                 {
-                    return "When you would play this card from your hand, by placing 1 of your [Shoutmon] as a digivolution card under this Digimon, reduce its play cost by 1 and place the cards in your trash as digivolution cards for a DigiXros.";
+                    return "When you would play this card, by placing 1 [Shoutmon] as a digivolution card under this Digimon, reduce its play cost by 1 and place the cards in your trash as digivolution cards for a DigiXros.";
                 }
 
                 bool CanSelectPermanentCondition(Permanent permanent)

--- a/Scripts/ICardEffect.cs
+++ b/Scripts/ICardEffect.cs
@@ -29,6 +29,7 @@ public abstract class ICardEffect
         SetIsDeclarative(false);
         SetIsInheritedEffect(false);
         SetIsLinkedEffect(false);
+        SetIsEffectOfCard(false);
         SetIsSecurityEffect(false);
         SetIsCounterEffect(false);
         SetIsDigimonEffect(false);
@@ -509,6 +510,23 @@ public abstract class ICardEffect
     public void SetIsLinkedEffect(bool isLinkededEffect)
     {
         IsLinkedEffect = isLinkededEffect;
+    }
+
+    #endregion
+
+    #region Whether this is a static effect on a card itself
+
+    bool _isEffectOfCard = false;
+
+    public bool IsEffectOfCard
+    {
+        get { return _isEffectOfCard; }
+        private set { _isEffectOfCard = value; }
+    }
+
+    public void SetIsEffectOfCard(bool isEffectOfCard)
+    {
+        IsEffectOfCard = isEffectOfCard;
     }
 
     #endregion

--- a/Scripts/Permanent.cs
+++ b/Scripts/Permanent.cs
@@ -1475,28 +1475,27 @@ public class Permanent
                     if (!cardSource.IsFlipped)
                     {
                         bool isTopCard = cardSource == TopCard;
-
-                        if (!isTopCard)
-                        {
-                            if (!IsDigimon)
-                            {
-                                continue;
-                            }
-                        }
+                        bool isDigimon = IsDigimon;
 
                         foreach (ICardEffect cardEffect in cardSource.cEntity_EffectController.GetCardEffects(timing, cardSource))
                         {
                             if (cardEffect != null)
                             {
-                                #region Entity, Inherited and Link effects
-
-                                if (cardEffect.IsInheritedEffect && !isTopCard)
+                                if (cardEffect.IsEffectOfCard)
                                 {
                                     _EffectList.Add(cardEffect);
                                     continue;
                                 }
 
-                                if (cardEffect.IsLinkedEffect && cardSource.IsLinked)
+                                #region Entity, Inherited and Link effects
+
+                                if (cardEffect.IsInheritedEffect && !isTopCard && isDigimon)
+                                {
+                                    _EffectList.Add(cardEffect);
+                                    continue;
+                                }
+
+                                if (cardEffect.IsLinkedEffect && cardSource.IsLinked && isDigimon)
                                 {
                                     _EffectList.Add(cardEffect);
                                     continue;


### PR DESCRIPTION
Change to allow a particular class of effects, labeled EffectOfCard, to always work even when under a tamer. For effects with no trigger condition such as "When this card would be played..."