### PR TITLE
Fix EX11-027 linking to invalid targets, doesn't place to digivolution cards, and no options not to link

### DIFF
--- a/CardEffect/EX11/Green/EX11_027.cs
+++ b/CardEffect/EX11/Green/EX11_027.cs
@@ -65,7 +65,7 @@ namespace DCGO.CardEffects.EX11
 
                 bool CanSelectLinkTarget(Permanent permanent, CardSource cardSource)
                 {
-                    return permanent.IsDigimon
+                    return CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
                         && permanent != card.PermanentOfThisCard()
                         && cardSource.CanLinkToTargetPermanent(permanent, false);
                 }
@@ -106,14 +106,12 @@ namespace DCGO.CardEffects.EX11
                         {
                             new (message: $"Link this Maquinamon", value : 1, spriteIndex: 0)
                         };
-                        int index = 1;
                         bool canLinkHand = CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
                         if (canLinkHand)
                         {
-                            selectionElements.Add( new (message: $"Link from Hand", value : 2, spriteIndex: 1));
-                            index++;
+                            selectionElements.Add( new (message: $"Link from Hand", value : 2, spriteIndex: 0));
                         }
-                        selectionElements.Add( new (message: $"Don't link", value: 3, spriteIndex: index));
+                        selectionElements.Add( new (message: $"Don't link", value: 3, spriteIndex: 1));
 
                         string selectPlayerMessage = canLinkHand ? "From which area will you link a Maquinamon?" : "Will you link your Maquinamon to another Digimon?";
                         string notSelectPlayerMessage = "The opponent is choosing from which area to select a card.";

--- a/Scripts/CardObjectController.cs
+++ b/Scripts/CardObjectController.cs
@@ -391,7 +391,14 @@ public class CardObjectController : MonoBehaviour
             {
                 if (permanent.cardSources.Contains(cardSource))
                 {
-                    yield return ContinuousController.instance.StartCoroutine(permanent.RemoveCardSource(cardSource));
+                    if (permanent.LinkedCards.Contains(cardSource))
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(permanent.RemoveLinkedCard(cardSource, trashCard: false));
+                    }
+                    else
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(permanent.RemoveCardSource(cardSource));
+                    }
                 }
             }
         }

--- a/Scripts/CardSource.cs
+++ b/Scripts/CardSource.cs
@@ -3049,27 +3049,30 @@ public class CardSource : MonoBehaviour
         {
             if (targetPermanent.TopCard != null && !targetPermanent.TopCard.IsToken)
             {
-                if (this.CanLink(PayCost, allowBreeding))
+                if(allowBreeding || !targetPermanent.TopCard.Owner.GetBreedingAreaPermanents().Contains(targetPermanent))
                 {
-                    if (linkCondition != null)
+                    if (this.CanLink(PayCost, allowBreeding))
                     {
-                        if (linkCondition.digimonCondition(targetPermanent))
+                        if (linkCondition != null)
                         {
-                            if (PayCost)
+                            if (linkCondition.digimonCondition(targetPermanent))
                             {
-                                int cost = linkCondition.cost;
-
-                                cost = GetChangedCostItselef(cost, SelectCardEffect.Root.Hand, new List<Permanent>() { targetPermanent }, checkAvailability: true);
-
-                                if (Owner.MaxMemoryCost < cost)
+                                if (PayCost)
                                 {
-                                    return false;
-                                }
-                            }
+                                    int cost = linkCondition.cost;
 
-                            return true;
+                                    cost = GetChangedCostItselef(cost, SelectCardEffect.Root.Hand, new List<Permanent>() { targetPermanent }, checkAvailability: true);
+
+                                    if (Owner.MaxMemoryCost < cost)
+                                    {
+                                        return false;
+                                    }
+                                }
+
+                                return true;
+                            }
                         }
-                    }
+                }
                 }
             }
         }

--- a/Scripts/Permanent.cs
+++ b/Scripts/Permanent.cs
@@ -1142,7 +1142,7 @@ public class Permanent
 
                 if (LinkedCards.Contains(addedDigivolutionCard))
                 {
-                    RemoveLinkedCard(addedDigivolutionCard, trashCard: false);
+                    yield return ContinuousController.instance.StartCoroutine(RemoveLinkedCard(addedDigivolutionCard, trashCard: false));
                 }
                 else if (addedDigivolutionCard == TopCard)
                 {


### PR DESCRIPTION
Link Cards were not correctly being cleaned from the permanent's LinkedCards array, meaning if the card was added back to the stack in any way it would still be considered a linked card