### PR TITLE
Post EX11: Fix BT24-090 Performance

### DIFF
--- a/CardEffect/BT24/Blue/BT24_090.cs
+++ b/CardEffect/BT24/Blue/BT24_090.cs
@@ -36,6 +36,7 @@ namespace DCGO.CardEffects.BT24
 
             #region All Turns - Security
 
+            #region Blocker
             if (timing == EffectTiming.None)
             {
                 bool PermanentCondition(Permanent permanent)
@@ -45,56 +46,147 @@ namespace DCGO.CardEffects.BT24
                         && permanent.TopCard.HasTSTraits;
                 }
 
-                #region Blocker
                 bool CanUseCondition()
                 {
                     return CardEffectCommons.IsExistInSecurity(card, false);
                 }
 
                 cardEffects.Add(CardEffectFactory.BlockerStaticEffect(permanentCondition: PermanentCondition, isInheritedEffect: false, card: card, condition: CanUseCondition));
-                #endregion
+                
+            }
+            #endregion
 
-                #region Alliance
-                AddSkillClass addSkillClass1 = new AddSkillClass();
-                addSkillClass1.SetUpICardEffect("Your Digimon gain <Alliance>", CanUseCondition1, card);
-                addSkillClass1.SetUpAddSkillClass(cardSourceCondition: CardSourceCondition, getEffects: GetEffects1);
-                cardEffects.Add(addSkillClass1);
+            #region Alliance
 
-                bool CardSourceCondition(CardSource cardSource)
-                {
-                    return CardEffectCommons.IsExistOnBattleAreaDigimon(cardSource) &&
-                           cardSource == cardSource.PermanentOfThisCard().TopCard &&
-                           PermanentCondition(cardSource.PermanentOfThisCard());
-                }
+            string GrantedAllianceHashstring(CardSource cardSource) => $"BT24_090_Alliance_On_{cardSource.CardIndex}_From_{card.CardIndex}";//Get unique reference of this card granting to particular cardsource
 
-                bool CanUseCondition1(Hashtable hashtable)
-                {
-                    return CardEffectCommons.IsExistInSecurity(card, false) &&
-                           CardEffectCommons.HasMatchConditionOwnersPermanent(card, HasOXII);
-                }
-
+            /// Alliance effect which is granted to all of your Digimon while this card is face up in security
+            /// The effect itself tracks if the card granting it is still present and if the conditions for granting are still met
+            ICardEffect GetAllianceEffect(CardSource cardSource)
+            {
                 bool HasOXII(Permanent permanent)
                 {
                     return permanent.TopCard.EqualsCardName("Neptunemon")
                         || permanent.TopCard.EqualsCardName("Venusmon");
                 }
 
-                List<ICardEffect> GetEffects1(CardSource cardSource, List<ICardEffect> effects, EffectTiming effectTiming)
+                bool Condition()
                 {
-                    if (effectTiming == EffectTiming.OnAllyAttack)
-                    {
-                        bool Condition()
-                        {
-                            return CardSourceCondition(cardSource);
-                        }
-
-                        effects.Add(CardEffectFactory.AllianceSelfEffect(false, cardSource, Condition));
-                    }
-
-                    return effects;
+                    return CardEffectCommons.IsExistInSecurity(card, false) //Is this card that provides the effect still providing the effect
+                        && cardSource == cardSource.PermanentOfThisCard().TopCard //Added effects don't check if it is inherited or not so have to check that this is the topcard
+                        && (cardSource.CardColors.Contains(CardColor.Blue) || cardSource.CardColors.Contains(CardColor.Yellow))
+                        && cardSource.HasTSTraits // Does this card meet conditions
+                        && CardEffectCommons.HasMatchConditionOwnersPermanent(card, HasOXII); // Is the condition for granting met
                 }
-                #endregion
+
+                ICardEffect cardEffect = CardEffectFactory.AllianceSelfEffect(false, cardSource, Condition);
+                cardEffect.SetHashString = GrantedAllianceHashstring(cardSource); // Unique identifier using exact card object references
+                return cardEffect;
             }
+
+            ///Grant all cards in a permanent the effect permanently
+            ///Grants to every card so effect can survive through degeneration
+            ///The effect's CanUseCondition will deactivate when the conditions for granting are not met
+            void GrantEffect(List<Permanent> permanents)
+            {
+                foreach (Permanent permanent in permanents)
+                {
+                    foreach(CardSource cardSource in permanent.cardSources)
+                    {
+                        if(!cardSource.HasDP || permanent.EffectList_ForCard(EffectTiming.OnAllyAttack, cardSource).Contains(effect => effect.HashString.equals(GrantedAllianceHashstring(cardSource))))
+                            continue; // if the card could not be a relevant top card or if it already has the effect, don't grant the effect
+
+                        Func<EffectTiming, ICardEffect> getCardEffect = GetCardEffectByEffectTiming(timing: EffectTiming.OnAllyAttack, cardEffect: GetAllianceEffect(cardSource));
+
+                        permanent.PermanentEffects.Add(getCardEffect);
+                    }
+                }
+            }
+
+            string SharedEffectDescription() => "(Security) [All Turns] All of your blue or yellow [TS] trait Digimon gain <Blocker>. While you have [Neptunemon] or [Venusmon], all of your blue or yellow [TS] trait Digimon gain <Alliance>."; 
+
+            bool IsYourPermanent(Permanent permanent) => CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(permanent, card);
+
+            #region Give permanents conditional Alliance on card added to security
+            if (timing == EffectTiming.OnAddSecurity)
+            {
+                ActivateClass activateClass = new();
+                activateClass.SetUpICardEffect("Set Up Alliance", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, SharedEffectDescription());
+                activateClass.SetIsBackgroundProcess(true);
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistInSecurity(card, false)
+                        && GetCardSourcesFromHashtable(hashtable).Contains(card);
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    List<Permanent> permanents = card.Owner.GetBattleAreaPermanents();
+                    GrantEffect(permanents);
+                    yield return null;
+                }
+            }
+            #endregion
+
+            #region Give permanents conditional Alliance on permanent enter
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new();
+                activateClass.SetUpICardEffect("Set Up Alliance", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, SharedEffectDescription());
+                activateClass.SetIsBackgroundProcess(true);
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistInSecurity(card, false)
+                        && (CardEffectCommons.CanTriggerOnPermanentPlay(hashtable, IsYourPermanent)
+                            || CardEffectCommons.CanTriggerWhenPermanentDigivolving(hashtable, IsYourPermanent));
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    List<Permanent> permanents = CardEffectCommons.GetHashtablesFromHashtable(hashtable)
+                            .Map(CardEffectCommons.GetPermanentFromHashtable)
+                            .Filter(IsYourPermanent);
+                    GrantEffect(permanents);
+                    yield return null;
+                }
+            }
+            #endregion
+
+            #region Give permanents conditional Alliance on card added to permanent stack
+            if(timing == EffectTiming.OnAddDigivolutionCards)
+            {
+                ActivateClass activateClass = new();
+                activateClass.SetUpICardEffect("Set Up Alliance", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, SharedEffectDescription());
+                activateClass.SetIsBackgroundProcess(true);
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistInSecurity(card, false)
+                        && CardEffectCommons.CanTriggerOnAddDigivolutionCard(
+                                hashtable: hashtable,
+                                permanentCondition: IsYourPermanent,
+                                cardEffectCondition: null,
+                                cardCondition: null);
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    List<Permanent> permanents = new List<Permanent>() { CardEffectCommons.GetPermanentFromHashtable };
+                    GrantEffect(permanents);
+                    yield return null;
+                }
+            }
+            #endregion
+
+            #endregion
 
             #endregion
 


### PR DESCRIPTION
Got my approach typed out but we can try Lewis's first.
Basically applies the alliance effect onto every relevant card on the board while this card is in security, and allows the CanUseCondition of that effect to track whether or not it still applies.
This should be more efficient than adding the effect every single effect check and then also checking the conditions.
Applies to every single card source to ensure it still works through any combination of dedigivolving or evolving or source tucking etc., but then only the topcard applies.
Uses Card Index to track if effect has already been added, in such a way that if the user ever somehow gets 2 in security they will correctly have 2 instances of Alliance from them. (Use Throne, Use Amethyst Mandala, Use Second identical Throne for example)
Applies to all cards upon itself being placed in security, then applies whenever a new card enters either as a new permanent entirely, a digivolution or if added to an existing permanent. Only ever for your side of the board though.

Same approach can work for Scapegoat, but will need to update Permanent.HasScapeGoat to actually check cardEffect.CanTrigger(null), as otherwise every one of your Digimon will show as having scapegoat under this approach