### PR TITLE
Fix EX11-059 sometimes incorrectly allows to select first condition with no valid second condition

### DIFF
--- a/Scripts/CardEffectCommons/DNADigivolveEffects.cs
+++ b/Scripts/CardEffectCommons/DNADigivolveEffects.cs
@@ -69,6 +69,8 @@ public partial class CardEffectCommons
                     {
                         foreach(Permanent secondPermanent in owner.GetBattleAreaDigimons().Filter(permanent => permanentCondition == null || permanentCondition(permanent)))
                         {
+                            if (secondPermanent == tempPermanent)
+                                continue;
                             if(DNACondition.elements[1].EvoRootCondition(secondPermanent))
                             {
                                 isValid = true;


### PR DESCRIPTION
If the card in trash could fulfill both conditions due to being dual coloured, it was incorrectly being counted again for the second condition of the Jogress.